### PR TITLE
Add test that shows the problem

### DIFF
--- a/tests/test_concurrent_download.py
+++ b/tests/test_concurrent_download.py
@@ -1,0 +1,20 @@
+import os
+from concurrent.futures import ThreadPoolExecutor
+from time import sleep
+
+import pytest
+
+from youseedee import ucd_data
+
+def test_concurrent_download(tmp_path):
+    """Download the ZIP twice at the same time and make sure it doesn't crash.
+    """
+    # Fake user home dir (where youseedee writes its files)
+    os.environ['HOME'] = str(tmp_path)
+    os.environ['USERPROFILE'] = str(tmp_path)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        future_1 = executor.submit(ucd_data, ord('a'))
+        sleep(0.1)
+        future_2 = executor.submit(ucd_data, ord('a'))
+        assert future_1.result() == future_2.result()


### PR DESCRIPTION
Hello Simon, this is a reproducer for the issue here: https://github.com/googlefonts/diffenator2/issues/97

It's a race condition when two process/instances of fontbakery/diffenator2 try to call youseedee at the same, there's a race for downloading and opening the ZIP.

The problem is on this line: https://github.com/simoncozens/youseedee/blob/master/lib/youseedee/__init__.py#L31, one thread will see the half-downloaded ZIP from the other and try to open it.

Possible mitigation would be to write a lock file next to the ZIP, that stays here until the download is finished. The process would be:
1. Check if ZIP present
2. Check if lock file present
    a) if yes, wait for it to go away
    b) if not, create it and download
3. Open the ZIP

I can add that code on Monday if you'd like