### PR TITLE
Always try and create `~/.youseedee`, handle exception

### DIFF
--- a/lib/youseedee/__init__.py
+++ b/lib/youseedee/__init__.py
@@ -30,8 +30,10 @@ UCD_URL = "https://unicode.org/Public/UCD/latest/ucd/UCD.zip"
 
 def ucd_dir():
     ucddir = os.path.expanduser("~/.youseedee")
-    if not os.path.isdir(ucddir):
+    try:
         os.mkdir(ucddir)
+    except FileExistsError:
+        pass
     return ucddir
 
 


### PR DESCRIPTION
This prevents a race condition where if multiple youseedees run `ucd_dir()` at once, they each try and create the directory, causing an exception in the slower one

Yes, we did see this in the real world 🫠 

![image](https://github.com/user-attachments/assets/0a89b20d-b656-4b3c-8f9d-766850a8d32c)
