### PR TITLE
We hit another data race in production!

### DIFF
--- a/lib/youseedee/__main__.py
+++ b/lib/youseedee/__main__.py
@@ -1,7 +1,9 @@
 import argparse
 import sys
+import os
+from filelock import FileLock
 
-from youseedee import ucd_data, download_files
+from youseedee import ucd_data, _download_files, ucd_dir
 
 
 def main(args=None):
@@ -19,7 +21,9 @@ def main(args=None):
 
     args = parser.parse_args(args)
     if args.force_download:
-        download_files()
+        file_lock = FileLock(os.path.join(ucd_dir(), ".youseedee_ensure_files.lock"))
+        with file_lock:
+            _download_files()
     char = sys.argv[1]
     if len(char) > 1:
         try:


### PR DESCRIPTION
The .zip file ended up getting extracted twice, and then a mkdir didn't like the `emoji/` folder already existing

```
 File "/home/runner/work/asdf/asdf/venv_bakery/lib/python3.11/site-packages/youseedee/__init__.py", line 296, in ucd_data
    out.update(props["datareader"](file, codepoint))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/asdf/asdf/venv_bakery/lib/python3.11/site-packages/youseedee/__init__.py", line 169, in dictget
    data = parsed_unicode_file(filename)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/asdf/asdf/venv_bakery/lib/python3.11/site-packages/youseedee/__init__.py", line 155, in parsed_unicode_file
    data = fileentry["reader"](filename)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/asdf/asdf/venv_bakery/lib/python3.11/site-packages/youseedee/__init__.py", line 127, in parse_file_semicolonsep
    ensure_files()
  File "/home/runner/work/asdf/asdf/venv_bakery/lib/python3.11/site-packages/youseedee/__init__.py", line 69, in ensure_files
    download_files()
  File "/home/runner/work/asdf/asdf/venv_bakery/lib/python3.11/site-packages/youseedee/__init__.py", line 98, in download_files
    zip_ref.extractall(ucd_dir())
  File "/opt/hostedtoolcache/Python/3.11.11/x64/lib/python3.11/zipfile.py", line 1702, in extractall
    self._extract_member(zipinfo, path, pwd)
  File "/opt/hostedtoolcache/Python/3.11.11/x64/lib/python3.11/zipfile.py", line 1752, in _extract_member
    os.mkdir(targetpath)
```

To mitigate this, we're moving away from [double-checked locking](https://www.wikiwand.com/en/articles/Double-checked_locking), which is a faulty way of handling the logic here. We must instead lock before even checking if we need to do anything

Note: this is a breaking change as two functions are now 'private'